### PR TITLE
Fix binary path in deployments

### DIFF
--- a/deploy/k8s-1.6/stable.yaml
+++ b/deploy/k8s-1.6/stable.yaml
@@ -72,7 +72,7 @@ spec:
               cpu: 10m
               memory: 64Mi
           command:
-            - ./k8s-ec2-srcdst
+            - /k8s-ec2-srcdst
           env:
             - name: AWS_REGION
               value: {{AWS_REGION}}


### PR DESCRIPTION
Seems the binary is in `/` not `/go`